### PR TITLE
Fix pour Firefox

### DIFF
--- a/assets/js/jquery/plugins/fake-select.js
+++ b/assets/js/jquery/plugins/fake-select.js
@@ -62,7 +62,7 @@ if (!jQuery.fn.FakeSelect) {
             setEvents: function() {
                 var self = this;
                 this.setValue();
-                this.el.on('keyup change', function() {
+                this.el.on('change keyup keypress', function() {
                     self.setValue();
                 });
                 this.el.on('focus', function() {


### PR DESCRIPTION
Salut,

Merci pour cet excellent plugin, simple, léger, et aucune perte d'accessibilité. Toutefois le fait de taper au clavier ne fonctionnait pas sur Firefox (la valeur du select n'était mise à jour qu'en quittant le champ).

J'ai testé plusieurs évènements de remplacement, et keyup semble régler le soucis. J'ai testé sur Opera, Safari, Chrome et Firefox et le comportement semble cette fois identique.

J'ai pas d'IE sous la main, faudrait tester pour être sûr ;-).

EDIT : en fait il est nécessaire d'ajouter les deux évènements, autrement cela ne fonctionne pas en choisissant la valeur avec la souris.

EDIT 2 : nécessaire également d'ajouter keypress, autrement le fait de rester appuyer sur la touche bas ou haut ne fonctionnait pas sur Firefox pour faire défiler toutes les options.
